### PR TITLE
Render battlefield and unit move

### DIFF
--- a/include/Game/Game.h
+++ b/include/Game/Game.h
@@ -65,6 +65,8 @@ public:
 
     bool checkTargetFieldHasEnemyUnit(const std::pair<int, int> &to, Players player) const;
 
+    bool checkTargetFieldObstacle(const std::pair<int, int> &to) const;
+
     bool checkMoveValidation(const std::pair<int, int> &from, const std::pair<int, int> &to,
                              Players currentPlayer) const;
 };

--- a/include/Game/Game.h
+++ b/include/Game/Game.h
@@ -15,7 +15,7 @@ public:
 
     void initializeBoard();
 
-    bool checkGameOver(Players currentPlayer);
+    bool checkGameOver(Players currentPlayer) override;
 
     bool canPlayerMove(Players player);
 
@@ -39,7 +39,7 @@ public:
 
     Field *getFieldPtr(const std::pair<int, int> &field) const;
 
-    bool handleAction(const std::pair<int, int> &from, const std::pair<int, int> &to, Players currentPlayer);
+    bool handleAction(const std::pair<int, int> &from, const std::pair<int, int> &to, Players currentPlayer) override;
 
     void transferUnit(const std::pair<int, int> &from, const std::pair<int, int> &to);
 

--- a/include/Game/Game.h
+++ b/include/Game/Game.h
@@ -23,6 +23,8 @@ public:
 
     void placeUnit(const std::pair<int, int> &to, const Players &player, const Ranks &rank);
 
+    std::shared_ptr<Unit> makeUnit(const Players &player, const Ranks &rank);
+
     bool checkUnitPlaceInBounds(const std::pair<int, int> &to) override;
 
     void removeUnit(const std::pair<int, int> &field) override;

--- a/include/Game/IGame.h
+++ b/include/Game/IGame.h
@@ -16,8 +16,6 @@ public:
 
     virtual void removeUnit(const SDL_Point &field) = 0;
 
-    virtual std::vector<std::vector<std::shared_ptr<Field> > > getUnitPlaceFields(const Players &player) = 0;
-
     virtual bool checkUnitPlaceInBounds(const std::pair<int, int> &to) = 0;
 
     virtual bool checkMoveInBounds(const std::pair<int, int> &to) const = 0;
@@ -41,17 +39,20 @@ public:
     bool getGameEnded() const { return gameEnded; }
     bool getGameStart() const { return gameStart; }
     bool getUnitPlacement() const { return unitPlacement; }
+    bool getBattleStart() const { return battleStart; }
     int getGridSize() const { return gridSize; }
 
     void setCurrentPlayer(const Players &player) { currentPlayer = player; }
     void setGameEnded(const bool &value) { gameEnded = value; }
     void setGameStart(const bool &value) { gameStart = value; }
     void setUnitPlacement(const bool &value) { unitPlacement = value; }
+    void setBattleStart(const bool &value) { battleStart = value; }
 
 protected:
     bool gameEnded = false;
     bool gameStart = false;
     bool unitPlacement = false;
+    bool battleStart = false;
     const int gridSize = 10;
     Players currentPlayer = Players::Red;
     std::vector<std::vector<std::shared_ptr<Field> > > battleField;

--- a/include/Game/IGame.h
+++ b/include/Game/IGame.h
@@ -28,7 +28,11 @@ public:
 
     virtual void middleMirrorBattlefield() = 0;
 
+    virtual bool handleAction(const std::pair<int, int> &from, const std::pair<int, int> &to, Players currentPlayer) = 0;
+
     virtual void resetGame() = 0;
+
+    virtual bool checkGameOver(Players currentPlayer) = 0;
 
     std::vector<Players> getPlayers() const { return players; }
     std::vector<Ranks> getPlayerUnits() const { return playerUnits; }

--- a/include/UI/UI.h
+++ b/include/UI/UI.h
@@ -40,7 +40,7 @@ public:
 
     void drawStartUnits();
 
-    void drawUnits();
+    void drawBattlefieldUnits();
 
     void drawBattlefieldUnits(const Players &currentPlayer);
 

--- a/include/UI/UI.h
+++ b/include/UI/UI.h
@@ -42,7 +42,7 @@ public:
 
     void drawUnits();
 
-    void drawBattlefield(const Players &currentPlayer);
+    void drawBattlefieldUnits(const Players &currentPlayer);
 
     void drawPlayerUI();
 

--- a/include/UI/UI.h
+++ b/include/UI/UI.h
@@ -38,6 +38,8 @@ public:
 
     void drawUnit(Ranks rank, Players player, int &x, int &y);
 
+    void drawUnit(Ranks rank, Players player, const int &x, const int &y, const int &i);
+
     void drawStartUnits();
 
     void drawBattlefieldUnits();

--- a/include/UI/UI.h
+++ b/include/UI/UI.h
@@ -48,7 +48,7 @@ public:
 
     void drawPlayerUI();
 
-    void drawMove(const Players &currentPlayer);
+    void drawMove();
 
     void drawHighlight(const SDL_Rect &rect, int thickness = 4);
 
@@ -56,14 +56,15 @@ public:
 
     void drawTexture(Texture &texture, SDL_Rect &rect, int width, int height, int x, int y);
 
-    void handleEvents(bool &gameEnded, bool &gameStart, bool &unitPlacement, Players &currentPlayer,
+    void handleEvents(bool &gameEnded, bool &gameStart,
+                      bool &unitPlacement, Players &currentPlayer,
                       const std::vector<Ranks> &playerUnits);
 
     void handleMouseDownEvent(const SDL_Event &e, bool &gameEnded, bool &gameStart, bool &unitPlacement,
                               Players &currentPlayer, const std::vector<Ranks> &playerUnits, bool &isDragging,
                               SDL_Point &originalPosition);
 
-    void handleMouseUpEvent(const SDL_Event &e, SDL_Point &originalPosition, const Players &currentPlayer);
+    void handleMouseUpEvent(const SDL_Event &e, SDL_Point &originalPosition, Players &currentPlayer);
 
     void handleMouseMotionEvent(const SDL_Event &e, const bool &isDragging);
 

--- a/source/Game/Game.cpp
+++ b/source/Game/Game.cpp
@@ -77,14 +77,6 @@ void Game::initializeBoard() {
     for (const auto [x, y]: obstacleLocations) {
         battleField[x][y]->setUnit(make_shared<Obstacle>());
     }
-
-    /*battleField[0][0]->setUnit(make_unique<Flag>(Players::Red));
-    battleField[0][1]->setUnit(make_unique<Bomb>(Players::Red));
-    battleField[0][2]->setUnit(make_unique<Marshal>(Players::Blue));
-    battleField[0][3]->setUnit(make_unique<Miner>(Players::Blue));
-    battleField[1][1]->setUnit(make_unique<Spy>(Players::Blue));
-    battleField[1][0]->setUnit(make_unique<Marshal>(Players::Red));
-    battleField[2][1]->setUnit(make_unique<Flag>(Players::Blue));*/
 }
 
 void Game::resetGame() {
@@ -119,16 +111,10 @@ bool Game::checkUnitPlaceInBounds(const pair<int, int> &to) {
 }
 
 void Game::changePlayer(Players &currentPlayer) {
-    /*if (currentPlayer == Players::Red)
-      middleMirrorBattlefield();*/
     currentPlayer = currentPlayer == Players::Red ? Players::Blue : Players::Red;
 }
 
 Field *Game::getFieldPtr(const std::pair<int, int> &field) const {
-    /*if (field.first < 0 && field.first >= battleField.size() &&
-        field.second < 0 && field.second >= battleField[0].size()) {
-        return nullptr; // Out of bounds check
-    }*/
     if (!checkMoveInBounds(field))
         return nullptr;
     return battleField[field.second][field.first].get();

--- a/source/Game/Game.cpp
+++ b/source/Game/Game.cpp
@@ -100,7 +100,7 @@ void Game::printBoard() const {
 }
 
 void Game::placeUnit(const pair<int, int> &to, const Players &player, const Ranks &rank) {
-    const auto unit = make_shared<ArmyUnit>(player, rank);
+    const auto unit = makeUnit(player, rank);
     battleField[to.second][to.first]->setUnit(unit);
 }
 

--- a/source/Game/Game.cpp
+++ b/source/Game/Game.cpp
@@ -223,7 +223,7 @@ void Game::handleCapture(const std::pair<int, int> &from, const std::pair<int, i
 
     if (toUnit && toUnit->getRank() == Ranks::Flag) {
         gameEnded = true;
-        cout << (fromUnit->getPlayer() == Players::Red ? "Blue" : "Red") << " wins by capturing the flag!" << endl;
+        cout << toString(currentPlayer) << " wins by capturing the flag!" << endl;
     }
 
     if (checkSpecialCaptureRules(fromUnit, toUnit, from, to)) return;

--- a/source/Game/Game.cpp
+++ b/source/Game/Game.cpp
@@ -32,23 +32,18 @@ void Game::run() {
             } else {
                 ui.renderBattlefield(currentPlayer);
             }
+
+            /*if (handleAction(movement.first, movement.second, currentPlayer)) {
+                //printBoard();
+
+                if (checkGameOver(currentPlayer)) {
+                    cout << "Game Over!" << endl;
+                    break;
+                }
+                currentPlayer = (currentPlayer == Players::Red) ? Players::Blue : Players::Red;
+                //ui.drawBattlefieldUnits(currentPlayer);
+            }*/
         }
-
-        /*pair<int, int> from, to;
-        cout << (currentPlayer == Players::Red ? "Red Player's Turn" : "Blue Player's Turn") << endl;
-
-        cout << "Enter your move (from_x from_y to_x to_y): ";
-        cin >> from.first >> from.second >> to.first >> to.second;
-        if (handleAction(from, to, currentPlayer)) {
-            printBoard();
-
-            if (checkGameOver(Players::Red) || checkGameOver(Players::Blue)) {
-                cout << "Game Over!" << endl;
-                break;
-            }
-
-            currentPlayer = (currentPlayer == Players::Red) ? Players::Blue : Players::Red;
-        }*/
     }
 }
 

--- a/source/Game/Game.cpp
+++ b/source/Game/Game.cpp
@@ -309,9 +309,18 @@ bool Game::checkTargetFieldHasEnemyUnit(const std::pair<int, int> &to, Players p
     return targetUnit && (targetUnit->getPlayer() != player);
 }
 
+bool Game::checkTargetFieldObstacle(const std::pair<int, int> &to) const {
+    auto targetUnit = getFieldPtr(to)->getUnitPtr();
+    return targetUnit && targetUnit->getRank() == Ranks::None;
+}
+
 bool Game::checkMoveValidation(const std::pair<int, int> &from, const std::pair<int, int> &to,
                                Players currentPlayer) const {
     auto unit = getFieldPtr(from)->getUnitPtr();
+    cout << checkMoveInBounds(to) << checkUnitMoveable(unit) << checkDistanceValidation(from, to) <<
+            checkIsOwnUnit(from, currentPlayer) << !checkTargetFieldObstacle(to) << endl;
+    cout << "Current player: " << toString(currentPlayer) << endl;
+    cout << "Unit owned by " << toString(unit->getPlayer()) << endl;
     return unit && checkMoveInBounds(to) && checkUnitMoveable(unit) && checkDistanceValidation(from, to) &&
-           checkIsOwnUnit(from, currentPlayer);
+           checkIsOwnUnit(from, currentPlayer) && !checkTargetFieldObstacle(to);
 }

--- a/source/Game/Game.cpp
+++ b/source/Game/Game.cpp
@@ -49,7 +49,8 @@ void Game::run() {
 
 bool Game::checkGameOver(Players currentPlayer) {
     if (gameEnded) return true; // Game already ended
-    return !canPlayerMove(currentPlayer); // Check if the current player can move
+    return !canPlayerMove(currentPlayer == Players::Blue ? Players::Red : Players::Blue);
+    // Check if the current player can move
 }
 
 bool Game::canPlayerMove(Players player) {

--- a/source/Game/Game.cpp
+++ b/source/Game/Game.cpp
@@ -281,9 +281,8 @@ Ranks Game::checkFieldUnitRank(const std::pair<int, int> &field) const {
 }
 
 bool Game::checkMoveInBounds(const std::pair<int, int> &to) const {
-    int boardSize = battleField.size();
-    return to.first >= 0 && to.first < boardSize &&
-           to.second >= 0 && to.second < boardSize;
+    return to.first >= 0 && to.first < gridSize &&
+           to.second >= 0 && to.second < gridSize;
 }
 
 bool Game::checkUnitMoveable(Unit *unit) const {

--- a/source/Game/Game.cpp
+++ b/source/Game/Game.cpp
@@ -269,7 +269,7 @@ void Game::executeStandardCapture(Unit *fromUnit, Unit *toUnit, const std::pair<
         cout << "Attacking unit was defeated!" << endl;
     } else {
         transferUnit(from, to);
-        cout << "Capture successful!" << endl;
+        cout << "Capture successful by: " << currentPlayer << endl;
     }
 }
 

--- a/source/Game/Game.cpp
+++ b/source/Game/Game.cpp
@@ -8,6 +8,7 @@
 #include <ArmyUnit.h>
 #include <Obstacle.h>
 #include <Bomb.h>
+#include <Scout.h>
 #include <Marshal.h>
 #include <Miner.h>
 #include <Spy.h>
@@ -101,6 +102,34 @@ void Game::printBoard() const {
 void Game::placeUnit(const pair<int, int> &to, const Players &player, const Ranks &rank) {
     const auto unit = make_shared<ArmyUnit>(player, rank);
     battleField[to.second][to.first]->setUnit(unit);
+}
+
+shared_ptr<Unit> Game::makeUnit(const Players &player, const Ranks &rank) {
+    switch (rank) {
+        case Ranks::Flag:
+            return make_shared<Flag>(player);
+        case Ranks::Spy:
+            return make_shared<Spy>(player);
+        case Ranks::Scout:
+            return make_shared<Scout>(player);
+        case Ranks::Miner:
+            return make_shared<Miner>(player);
+        case Ranks::Sergeant:
+        case Ranks::Lieutenant:
+        case Ranks::Captain:
+        case Ranks::Major:
+        case Ranks::Colonel:
+        case Ranks::General:
+            return std::make_shared<ArmyUnit>(player, rank);
+        case Ranks::Marshal:
+            return make_shared<Marshal>(player);
+        case Ranks::Bomb:
+            return make_shared<Bomb>(player);
+        case Ranks::None:
+            return make_shared<Obstacle>();
+        default:
+            nullptr;
+    }
 }
 
 bool Game::checkUnitPlaceInBounds(const pair<int, int> &to) {

--- a/source/UI/UI.cpp
+++ b/source/UI/UI.cpp
@@ -442,17 +442,17 @@ void UI::handleMouseUpEvent(const SDL_Event &e, SDL_Point &originalPosition,
 }
 
 SDL_Point UI::calculateGridPosition(const SDL_Point &position, const Players &currentPlayer) const {
-    if (currentPlayer == Players::Blue)
+    if (!game.getUnitPlacement())
         return {
-            (position.x / (battlefieldRect.w / 10) * (battlefieldRect.w / 10) + 16) / 80,
-            (position.y / (battlefieldRect.h / 10) * (battlefieldRect.h / 10) + 16) / 80
+            battlefieldRect.w / 80 - 1 - (position.x + 10) / 80,
+            position.y - 490 < 0 ? -1 : battlefieldRect.h / 80 - 1 - (position.y + 10) / 80
         };
-
     return {
-        battlefieldRect.w / 80 - 1 - (originalPosition.x + 10) / 80,
-        originalPosition.y - 490 < 0 ? -1 : battlefieldRect.h / 80 - 1 - (originalPosition.y + 10) / 80
+        (position.x / (battlefieldRect.w / 10) * (battlefieldRect.w / 10) + 16) / 80,
+        (position.y / (battlefieldRect.h / 10) * (battlefieldRect.h / 10) + 16) / 80
     };
 }
+
 
 SDL_Point UI::snapToGrid(const int mouseX, const int mouseY) const {
     const int snapX = mouseX / (battlefieldRect.w / game.getGridSize()) * (battlefieldRect.w / game.getGridSize()) + 16;

--- a/source/UI/UI.cpp
+++ b/source/UI/UI.cpp
@@ -11,7 +11,7 @@ using namespace std;
 
 static auto path = (filesystem::current_path().parent_path() / ".." / "resources/").u8string();
 
-SDL_Rect battlefieldRect = {10, 10, 800, 800};
+SDL_Rect battlefieldRect;
 SDL_Rect quitButtonRect;
 SDL_Rect playButtonRect;
 SDL_Rect restartButtonRect;
@@ -272,7 +272,8 @@ bool isMouseInsideRect(int mouseX, int mouseY, SDL_Rect &rect) {
             mouseY < rect.y + rect.h);
 }
 
-void UI::handleEvents(bool &gameEnded, bool &gameStart, bool &unitPlacement, Players &currentPlayer,
+void UI::handleEvents(bool &gameEnded, bool &gameStart, bool &unitPlacement,
+                      Players &currentPlayer,
                       const vector<Ranks> &playerUnits) {
     SDL_Event e;
 
@@ -300,7 +301,6 @@ void UI::handleEvents(bool &gameEnded, bool &gameStart, bool &unitPlacement, Pla
     }
 }
 
-
 void UI::handleMouseDownEvent(const SDL_Event &e, bool &gameEnded, bool &gameStart, bool &unitPlacement,
                               Players &currentPlayer, const vector<Ranks> &playerUnits, bool &isDragging,
                               SDL_Point &originalPosition) {
@@ -321,7 +321,10 @@ void UI::handleMouseDownEvent(const SDL_Event &e, bool &gameEnded, bool &gameSta
         Players::Blue) {
         game.changePlayer(currentPlayer);
         game.middleMirrorBattlefield();
+        drawBattlefieldUnits(currentPlayer);
         unitPlacement = true;
+        game.setBattleStart(true);
+        unitPlacerRects.clear();
         return;
     }
 
@@ -336,14 +339,25 @@ void UI::handleMouseDownEvent(const SDL_Event &e, bool &gameEnded, bool &gameSta
         return;
     }
 
-    for (auto &unitRect: unitPlacerRects) {
-        if (isMouseInsideRect(mouseX, mouseY, unitRect)) {
-            isDragging = true;
-            selectedRect = &unitRect;
-            originalPosition = {selectedRect->x, selectedRect->y};
-            break;
+    if (!unitPlacerRects.empty())
+        for (auto &unitPlacerRect: unitPlacerRects) {
+            if (isMouseInsideRect(mouseX, mouseY, unitPlacerRect)) {
+                isDragging = true;
+                selectedPlacerRect = &unitPlacerRect;
+                originalPosition = {selectedPlacerRect->x, selectedPlacerRect->y};
+                break;
+            }
         }
-    }
+
+    if (!unitRects.empty())
+        for (auto &unitRect: unitRects) {
+            if (isMouseInsideRect(mouseX, mouseY, unitRect)) {
+                isDragging = true;
+                selectedRect = &unitRect;
+                originalPosition = {selectedRect->x, selectedRect->y};
+                break;
+            }
+        }
 }
 
 void UI::handleMouseMotionEvent(const SDL_Event &e, const bool &isDragging) {

--- a/source/UI/UI.cpp
+++ b/source/UI/UI.cpp
@@ -455,8 +455,10 @@ SDL_Point UI::calculateGridPosition(const SDL_Point &position, const Players &cu
 
 
 SDL_Point UI::snapToGrid(const int mouseX, const int mouseY) const {
-    const int snapX = mouseX / (battlefieldRect.w / game.getGridSize()) * (battlefieldRect.w / game.getGridSize()) + 16;
-    const int snapY = mouseY / (battlefieldRect.h / game.getGridSize()) * (battlefieldRect.h / game.getGridSize()) + 16;
+    const int snapX = mouseX / (battlefieldRect.w / game.getGridSize()) * (battlefieldRect.w / game.getGridSize()) +
+                      16;
+    const int snapY = mouseY / (battlefieldRect.h / game.getGridSize()) * (battlefieldRect.h / game.getGridSize()) +
+                      16;
     return {snapX, snapY};
 }
 

--- a/source/UI/UI.cpp
+++ b/source/UI/UI.cpp
@@ -462,7 +462,12 @@ SDL_Point UI::snapToGrid(const int mouseX, const int mouseY) const {
     return {snapX, snapY};
 }
 
-void UI::drawMove(const Players &currentPlayer) {
+void UI::drawMove() {
+    if (isDragging && selectedPlacerRect != nullptr) {
+        drawUnit(selectedPlacerRect);
+        drawHighlight(*selectedPlacerRect);
+    }
+
     if (isDragging && selectedRect != nullptr) {
         drawUnit(selectedRect);
         drawHighlight(*selectedRect);

--- a/source/UI/UI.cpp
+++ b/source/UI/UI.cpp
@@ -191,16 +191,14 @@ void UI::drawStartUnits() {
     }
 }
 
-/*void UI::drawUnits() {
-    for (auto &field: game.getBattlefield()) {
-        for (auto &cell: field) {
-            Texture unitImage = loadTexture(
-                path + "Units/" + toString(cell->getUnit()->getPlayer()) + toString(cell->getUnit()->getRank()) +
-                ".bmp");
-            unitImage.render(renderer, &unitRect);
-        }
+void UI::drawBattlefieldUnits() {
+    for (auto &rect: unitRects) {
+        Texture unitImage = loadTexture(
+            path + "Units/" + toString(rect.player) + toString(rect.rank) +
+            ".bmp");
+        unitImage.render(renderer, &rect);
     }
-}*/
+}
 
 void UI::drawStartUnits(const vector<Ranks> &playerUnits, const Players &player) {
     int xPos = 820;

--- a/source/UI/UI.cpp
+++ b/source/UI/UI.cpp
@@ -244,6 +244,19 @@ void UI::drawUnit(Ranks rank, Players player, int &x, int &y) {
     unitImage.render(renderer, &rect);
 }
 
+void UI::drawUnit(const Ranks rank, const Players player, const int &x, const int &y, const int &i) {
+    Texture unitImage = loadTexture(path + "Units/" + toString(player) + toString(rank) + ".bmp");
+
+    SDL_UnitRect rect(rank, player);
+    rect.h = 70;
+    rect.w = 70;
+    rect.x = x * 80 + 16;
+    rect.y = y * 80 + 16;
+
+    unitImage.render(renderer, &rect);
+    unitRects[i] = rect;
+}
+
 void UI::drawTexture(Texture &texture, SDL_Rect &rect, int width, int height, int x, int y) {
     rect.h = height;
     rect.w = width;

--- a/source/UI/UI.cpp
+++ b/source/UI/UI.cpp
@@ -98,22 +98,29 @@ void UI::renderUnitPlacement(const Players &currentPlayer, const vector<Ranks> &
         drawStartUnits(playerUnits, currentPlayer);
 
     if (currentPlayer == Players::Blue)
-        drawBattlefield(currentPlayer);
+        drawBattlefieldUnits(currentPlayer);
 
-    drawMove(currentPlayer);
+    drawMove();
 
     SDL_RenderPresent(renderer);
 }
 
-void UI::drawBattlefield(const Players &currentPlayer) {
+void UI::drawBattlefieldUnits(const Players &currentPlayer) {
+    unitRects.clear();
+    unitRects.resize(game.getGridSize() * game.getGridSize());
     auto battleField = game.getBattlefield();
+    int x = 0;
     for (int i = 0; i < battleField.size(); i++) {
         for (int j = 0; j < battleField[i].size(); j++) {
-            if (battleField[i][j]->getUnit() != nullptr && battleField[i][j]->getUnit()->getRank() != Ranks::None)
+            if (battleField[i][j]->getUnit() != nullptr && battleField[i][j]->getUnit()->getRank() != Ranks::None) {
                 if (battleField[i][j]->getUnit()->getPlayer() == currentPlayer)
-                    drawUnit(battleField[i][j]->getUnit()->getRank(), battleField[i][j]->getUnit()->getPlayer(), j, i);
+                    drawUnit(battleField[i][j]->getUnit()->getRank(), battleField[i][j]->getUnit()->getPlayer(), j,
+                             i, x);
                 else
-                    drawUnit(Ranks::None, battleField[i][j]->getUnit()->getPlayer(), j, i);
+                    drawUnit(Ranks::None, battleField[i][j]->getUnit()->getPlayer(), j,
+                             i, x);
+                x++;
+            }
         }
     }
 }
@@ -123,8 +130,8 @@ void UI::renderBattlefield(const Players &currentPlayer) {
     SDL_RenderClear(renderer);
 
     drawPlayerUI();
-    drawBattlefield(currentPlayer);
-    drawMove(currentPlayer);
+    drawBattlefieldUnits();
+    drawMove();
 
     SDL_RenderPresent(renderer);
 }

--- a/source/UI/UI.cpp
+++ b/source/UI/UI.cpp
@@ -364,6 +364,11 @@ void UI::handleMouseMotionEvent(const SDL_Event &e, const bool &isDragging) {
     int mouseX = e.motion.x;
     int mouseY = e.motion.y;
 
+    if (isDragging && selectedPlacerRect != nullptr) {
+        selectedPlacerRect->x = mouseX - selectedPlacerRect->w / 2;
+        selectedPlacerRect->y = mouseY - selectedPlacerRect->h / 2;
+    }
+
     if (isDragging && selectedRect != nullptr) {
         selectedRect->x = mouseX - selectedRect->w / 2;
         selectedRect->y = mouseY - selectedRect->h / 2;

--- a/source/UI/UI.cpp
+++ b/source/UI/UI.cpp
@@ -375,7 +375,8 @@ void UI::handleMouseMotionEvent(const SDL_Event &e, const bool &isDragging) {
     }
 }
 
-void UI::handleMouseUpEvent(const SDL_Event &e, SDL_Point &originalPosition, const Players &currentPlayer) {
+void UI::handleMouseUpEvent(const SDL_Event &e, SDL_Point &originalPosition,
+                            Players &currentPlayer) {
     int mouseX = e.button.x;
     int mouseY = e.button.y;
     int flooredX = 0;
@@ -383,24 +384,53 @@ void UI::handleMouseUpEvent(const SDL_Event &e, SDL_Point &originalPosition, con
 
     auto snappedPosition = snapToGrid(mouseX, mouseY);
 
-    if (currentPlayer == Players::Blue) {
-        flooredX = (snappedPosition.x + 10) / 80;
-        flooredY = snappedPosition.y - 490 < 0 ? -1 : (snappedPosition.y + 10) / 80;
+    if (!game.getUnitPlacement()) {
+        if (currentPlayer == Players::Blue) {
+            flooredX = (snappedPosition.x + 10) / 80;
+            flooredY = snappedPosition.y - 490 < 0 ? -1 : (snappedPosition.y + 10) / 80;
+        } else {
+            flooredX = battlefieldRect.w / 80 - 1 - (snappedPosition.x + 10) / 80;
+            flooredY = snappedPosition.y - 490 < 0 ? -1 : battlefieldRect.h / 80 - 1 - (snappedPosition.y + 10) / 80;
+        }
     } else {
-        flooredX = battlefieldRect.w / 80 - 1 - (snappedPosition.x + 10) / 80;
-        flooredY = snappedPosition.y - 490 < 0 ? -1 : battlefieldRect.h / 80 - 1 - (snappedPosition.y + 10) / 80;
+        flooredX = (snappedPosition.x + 10) / 80;
+        flooredY = snappedPosition.y < 0 ? -1 : (snappedPosition.y + 10) / 80;
     }
 
-    if (selectedRect != nullptr) {
+    if (selectedPlacerRect != nullptr) {
         //cout << game.checkUnitPlaceInBounds({flooredX, flooredY}) << endl;
         if (game.checkMoveInBounds({flooredX, flooredY}) && game.checkTargetFieldEmpty({flooredX, flooredY})) {
-            selectedRect->x = snappedPosition.x;
-            selectedRect->y = snappedPosition.y;
+            selectedPlacerRect->x = snappedPosition.x;
+            selectedPlacerRect->y = snappedPosition.y;
             auto pos = calculateGridPosition(originalPosition, currentPlayer);
             if (game.checkMoveInBounds({pos.x, pos.y}) && !game.checkTargetFieldEmpty({pos.x, pos.y})) {
                 game.removeUnit(pos);
             }
-            game.placeUnit({flooredX, flooredY}, selectedRect->player, selectedRect->rank);
+            game.placeUnit({flooredX, flooredY}, selectedPlacerRect->player, selectedPlacerRect->rank);
+        } else {
+            selectedPlacerRect->x = originalPosition.x;
+            selectedPlacerRect->y = originalPosition.y;
+        }
+        isDragging = false;
+        selectedPlacerRect = nullptr;
+        originalPosition = {0, 0};
+    }
+
+    if (selectedRect != nullptr) {
+        auto from = calculateGridPosition(originalPosition, currentPlayer);
+        cout << "FROM X: " << from.x << " FROM Y: " << from.y << endl;
+        auto to = calculateGridPosition(snappedPosition, currentPlayer);
+        cout << "TO X: " << flooredX << " TO Y: " << flooredY << endl;
+        if (game.handleAction({from.x, from.y}, {flooredX, flooredY},
+                              currentPlayer)) {
+            selectedRect->x = snappedPosition.x;
+            selectedRect->y = snappedPosition.y;
+            if (game.checkGameOver(currentPlayer))
+                game.setGameEnded(true);
+            game.changePlayer(currentPlayer);
+            game.middleMirrorBattlefield();
+            SDL_Delay(300);
+            drawBattlefieldUnits(currentPlayer);
         } else {
             selectedRect->x = originalPosition.x;
             selectedRect->y = originalPosition.y;

--- a/source/UI/UI.cpp
+++ b/source/UI/UI.cpp
@@ -18,11 +18,11 @@ SDL_Rect restartButtonRect;
 SDL_Rect nextButtonRect;
 SDL_Rect logoRect;
 vector<SDL_UnitRect> unitPlacerRects;
-vector<SDL_Rect> unitRects;
+vector<SDL_UnitRect> unitRects;
 bool isDragging = false;
 SDL_Point originalPosition;
+SDL_UnitRect *selectedPlacerRect = nullptr;
 SDL_UnitRect *selectedRect = nullptr;
-
 
 UI::UI(IGame &game) : window(nullptr), renderer(nullptr), game(game) {
 }


### PR DESCRIPTION
Fulfill #21 issue

1. Check game over for next player
2. Remove unnecessary comments
3. Add makeUnit method
4. Use makeUnit for placeUnit
5. Add checkTargetFieldObstacle method
6. Change handleAction and checkGameOver method to virtual
7. Add battleStart and getter, setter
8. Add selectedPlacerRect SDL_UnitRect
9. Change drawBattlefield to drawBattlefieldUnits
10. Add drawBattlefieldUnits overload method
11. Add drawUnit overload method
12. Change handleMouseDownEvent functionality
13. Change handleMouseUpEvent functionality
14. Change calculateGridPosition functionality
15. Change snapToGrid functionality
16. Change drawMove functionality